### PR TITLE
Find Mobu and Unreal install locations using windows registry

### DIFF
--- a/package.py
+++ b/package.py
@@ -5,6 +5,7 @@ import sys
 import json
 import re
 import subprocess
+import winreg
 
 """ creats a zip file release """
 
@@ -19,15 +20,12 @@ def get_version():
     
     
 
-def build_ue(plugin, ue_base, version):
+def build_ue(plugin, ue_base, version, ue_install_path):
 
     out = ue_base + "\\" + version + "\\PeelVCam"
-    
-    exe = r"d:\UnrealEngine\UE_" + version + "\Engine\Build\BatchFiles\RunUAT.bat"
-    
-    if not os.path.isfile(exe) :
-        exe = r"d:\EpicGames\UE_" + version + "\Engine\Build\BatchFiles\RunUAT.bat"
-      
+
+    exe = rf"{ue_install_path}\Engine\Build\BatchFiles\RunUAT.bat"
+
     if not os.path.isfile(exe) :      
         raise RuntimeError("Could not find unreal: " + version)
     
@@ -39,13 +37,15 @@ def build_ue(plugin, ue_base, version):
             "-Rocket",
             "-VS2022"
             ]
-            
-    pr = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-    out, error = pr.communicate()
-    print(out.decode("utf8"), error.decode('utf8'))
-    
-    if pr.returncode != 0:
-        raise RuntimeError("Plugin Build Failed")
+
+    try:
+        pr = subprocess.Popen(cmd, shell=True)
+        pr.wait()
+
+        if pr.returncode != 0:
+            raise RuntimeError("Plugin Build Failed")
+    except Exception as ex:
+        print(ex)
 
 
 version_input = get_version()
@@ -69,23 +69,27 @@ for d, _, f in os.walk(out_dir):
         out = os.path.join(base, each_file)
         print(out)
         fp.write(src, out)
+fp.close()
 
 # Unreal    
-# unreal_src_plugin = os.path.abspath("plugins/unreal/Open3DStream/Open3DStream.uplugin")
+unreal_src_plugin = os.path.abspath("plugins/unreal/Open3DStream/Open3DStream.uplugin")
 unreal_dst_base = os.path.join(cwd, "plugins", "unreal")
 
-unreal_src_plugin = r"D:\P4_PD\o3ds\Plugins\Open3DStream\Open3DStream.uplugin"
-
-build_ue(unreal_src_plugin, unreal_dst_base, "5.0")
-build_ue(unreal_src_plugin, unreal_dst_base, "5.1")
-build_ue(unreal_src_plugin, unreal_dst_base, "5.2")
-build_ue(unreal_src_plugin, unreal_dst_base, "5.3")
-
-
+ue_registry_prefix_path = r'SOFTWARE\EpicGames\Unreal Engine'
+ue_registry_prefix_key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, ue_registry_prefix_path, 0, winreg.KEY_READ)
+ue_version_index = 0
+while True:
+    try:
+        ue_version = winreg.EnumKey(ue_registry_prefix_key, ue_version_index)
+        ue_version_key = winreg.OpenKey(ue_registry_prefix_key, ue_version, 0, winreg.KEY_READ)
+        ue_path, _ = winreg.QueryValueEx(ue_version_key, "InstalledDirectory")
+        build_ue(unreal_src_plugin, unreal_dst_base, ue_version, ue_path)
+        ue_version_index = ue_version_index + 1
+    except OSError:
+        break
 
 raise RuntimeError("Here")
-fp.close()    
-        
+
 #installer
 
 nsis = "C:/Program Files (x86)/NSIS/makensis.exe"

--- a/plugins/mobu/CMakeLists.txt
+++ b/plugins/mobu/CMakeLists.txt
@@ -14,43 +14,51 @@ function(build_mobu version path)
   set(mobu_target O3DSMobu${version}Device)
   add_library(${mobu_target} SHARED ${SRCS} )
 
-  if(${version} STREQUAL "2024")
-     target_compile_definitions(${mobu_target} PUBLIC ORSDKPRODUCT_VERSION=ORSDK2024 )
+  if(${version} GREATER_EQUAL "2024")
+     target_compile_definitions(${mobu_target} PUBLIC ORSDKPRODUCT_VERSION=ORSDK${version} )
   endif()
   
   target_link_libraries(${mobu_target} fbsdk.lib opengl32.lib glu32.lib Ws2_32.lib open3dstreamstatic ${NNG_LIBRARY})
-  target_include_directories(${mobu_target} PUBLIC "${path}/include" ${CMAKE_CURENT_LIST_DIR}../src)
-  target_link_directories(${mobu_target} PUBLIC "${path}/lib/x64" "${path}/lib/x64/HIK2016")
+  target_include_directories(${mobu_target} PUBLIC "${path}/OpenRealitySDK/include" ${CMAKE_CURENT_LIST_DIR}../src)
+  target_link_directories(${mobu_target} PUBLIC "${path}/OpenRealitySDK/lib/x64" "${path}/OpenRealitySDK/lib/x64/HIK2016")
   target_compile_definitions(${mobu_target} PUBLIC NNG_STATIC_LIB)
-  foreach(mbdir "C:/Program Files/Autodesk/MotionBuilder ${version}/bin/x64"
-	            "D:/Programs/Autodesk/MotionBuilder ${version}/bin/x64")
-
-    install(TARGETS ${mobu_target} RUNTIME DESTINATION "plugins/mobu")
-    set_target_properties(${mobu_target} PROPERTIES VS_DEBUGGER_COMMAND "${mbdir}/motionbuilder.exe")
-  endforeach()
+  install(TARGETS ${mobu_target} RUNTIME DESTINATION "plugins/mobu")
+  set_target_properties(${mobu_target} PROPERTIES VS_DEBUGGER_COMMAND "${path}/bin/x64/motionbuilder.exe")
 endfunction()
 
-if(EXISTS  "M:/code/api/windows/mobu/2018/OpenRealitySDK")
-build_mobu("2018" "M:/code/api/windows/mobu/2018/OpenRealitySDK")
-endif()
+# Query the registry to find subkeys (versions)
+set(MOTIONBUILDER_REG_PREFIX "HKEY_LOCAL_MACHINE\\SOFTWARE\\Autodesk\\MotionBuilder")
+execute_process(
+  COMMAND reg query ${MOTIONBUILDER_REG_PREFIX}
+  OUTPUT_VARIABLE MOTIONBUILDER_REG_OUTPUT
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
-if(EXISTS  "M:/code/api/windows/mobu/2019/OpenRealitySDK")
-build_mobu("2019" "M:/code/api/windows/mobu/2019/OpenRealitySDK")
-endif()
+if(MOTIONBUILDER_REG_OUTPUT)
+  # Split the registry output into lines to extract version information
+  string(REGEX MATCHALL "HKEY_LOCAL_MACHINE\\\\[^\n\r]+" MOTIONBUILDER_VERSIONS ${MOTIONBUILDER_REG_OUTPUT})
 
-if(EXISTS  "M:/code/api/windows/mobu/2020/OpenRealitySDK")
-build_mobu("2020" "M:/code/api/windows/mobu/2020/OpenRealitySDK")
-endif()
+  if (MOTIONBUILDER_VERSIONS)
+    # Loop through all found versions
+    foreach (VERSION_KEY ${MOTIONBUILDER_VERSIONS})
 
-if(EXISTS  "M:/code/api/windows/mobu/2022/OpenRealitySDK")
-build_mobu("2022" "M:/code/api/windows/mobu/2022/OpenRealitySDK")
-endif()
+      string(REPLACE "${MOTIONBUILDER_REG_PREFIX}\\" "" MOBU_VERSION ${VERSION_KEY})
+      message(STATUS "Found MotionBuilder version: ${MOBU_VERSION}")
+      
+      # Query the InstallPath for each version
+      GET_FILENAME_COMPONENT(MOTIONBUILDER_INSTALL_PATH "[${VERSION_KEY};InstallPath]" ABSOLUTE CACHE)
 
-if(EXISTS  "M:/code/api/windows/mobu/2023/OpenRealitySDK")
-build_mobu("2023" "M:/code/api/windows/mobu/2023/OpenRealitySDK")
+      if (MOTIONBUILDER_INSTALL_PATH)
+        message(STATUS "MotionBuilder ${MOBU_VERSION} is installed at: ${MOTIONBUILDER_INSTALL_PATH}")
+        build_mobu(${MOBU_VERSION} ${MOTIONBUILDER_INSTALL_PATH})
+      else()
+        message(WARNING "Failed to get the installation path for MotionBuilder version: ${MOBU_VERSION}")
+      endif()
+    endforeach()
+  else()
+      message(WARNING "No Autodesk MotionBuilder versions found in the registry.")
+  endif()
+else()
+  message(WARNING "Autodesk MotionBuilder is not installed or registry key is missing.")
 endif()
-
-if(EXISTS  "M:/code/api/windows/mobu/2024/OpenRealitySDK")
-build_mobu("2024" "M:/code/api/windows/mobu/2024/OpenRealitySDK")
-endif()
-


### PR DESCRIPTION
When installing MotionBuilder and Unreal Engine on my computer, I noticed I had to change all hardcoded paths to make the build work.

This is painful for whoever wants to contribute to this project. So I changed all hardcoded paths into dynamically found paths using the Windows registry.
